### PR TITLE
Sprint 1 - Correction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.n3ksu</groupId>
     <artifactId>waterfall</artifactId>
-    <version>0.1.0</version>
+    <version>1.0.0</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/waterfall/plateau/servlet/FrontServlet.java
+++ b/src/main/java/waterfall/plateau/servlet/FrontServlet.java
@@ -1,22 +1,67 @@
 package waterfall.plateau.servlet;
 
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
 
+@WebServlet("/")
 public class FrontServlet extends HttpServlet {
+    private RequestDispatcher defaultDispatcher;
+
     @Override
-    public void service(HttpServletRequest req, HttpServletResponse res)
-            throws IOException {
-        StringBuffer requestURLBuffer = req.getRequestURL();
-        String requestURLString = requestURLBuffer.toString();
+    public void init() {
+        defaultDispatcher = findDefaultDispatcher()
+                .orElseThrow(() -> new RuntimeException("The default dispatcher cannot be found"));
+    }
 
-        res.setContentType("text/plain");
+    private Optional<RequestDispatcher> findDefaultDispatcher() {
+        return Optional.ofNullable(getServletContext().getNamedDispatcher("default"));
+    }
 
-        PrintWriter printWriter = res.getWriter();
-        printWriter.print(requestURLString);
+    @Override
+    public void service(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String resourcePath = getResourcePath(request);
+        Optional<URL> optionalURL = findResource(resourcePath);
+
+        if (optionalURL.isPresent()) {
+            delegateToDefaultDispatcher(request, response);
+        } else {
+            handle(resourcePath, response);
+        }
+    }
+
+    private void handle(String resourcePath, HttpServletResponse response) throws IOException {
+        response.setContentType("text/plain;charset=UTF-8");
+
+        try (PrintWriter out = response.getWriter()) {
+            out.print(resourcePath);
+        }
+    }
+
+    private void delegateToDefaultDispatcher(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        defaultDispatcher.forward(request, response);
+    }
+
+    private Optional<URL> findResource(String resourcePath) throws MalformedURLException {
+        return Optional.ofNullable(getServletContext().getResource(resourcePath));
+    }
+
+    private String getResourcePath(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        String resourcePath = requestURI.substring(contextPath.length());
+
+        return resourcePath.isEmpty() ? "/" : resourcePath;
     }
 }


### PR DESCRIPTION
Previously waterfall's client needed to have a web.xml inside of the webapp folder.
Now, waterfall use the annotation **@WebServlet** provided by jakarta to catch any url.

Also, previously the behaviour of the FrontServlet was that any resource requested, even present on the server, was responded with the "content-type: text/plain then print(url)".
*.jsp file was the only exception to this, if they were found we got the pages on the screen (if free from any error) or else we got a 404 Not Found error.

Now, if the static resource is available on the server (e.g a css file) FrontServlet will delegate the handling of the request to the default dispatcher of the servlet container,
so that it's no longer the previous behavior of a blank page with just a text with the url requested but it now serves the resource properly (now your jsp file can have css).